### PR TITLE
Simplify usage of MAX485 board

### DIFF
--- a/sensor/sensor.ino
+++ b/sensor/sensor.ino
@@ -1,6 +1,8 @@
 // If connect to serial port over TCP, define the following
 // #define SERIAL_OVER_IP_ADDR "192.168.178.131"
 
+// If using MAX485 board which requires RTS_PIN for request-to-send, define the following:
+// #define MAX485 TRUE;
 
 #ifdef ESP32
 #include <WiFi.h>
@@ -61,6 +63,9 @@ WiFiClient tub = clients[1];
 SoftwareSerial tub;
 #define RX_PIN D6
 #define TX_PIN D7
+#endif
+#ifdef MAX485
+#define RTS_PIN D1 // RS485 direction control, RequestToSend TX or RX, required for MAX485 board.
 #endif
 #endif
 
@@ -157,6 +162,10 @@ void setup() {
 
 
 #ifndef SERIAL_OVER_IP_ADDR
+#ifdef MAX485
+  pinMode(RTS_PIN, OUTPUT);
+  digitalWrite(RTS_PIN, LOW);
+#endif
 #ifdef ESP32
   Serial.printf("Setting serial port as pins %u, %u\n", RX_PIN, TX_PIN);
   tub.begin(9600, SERIAL_8N1, RX_PIN, TX_PIN);


### PR DESCRIPTION
Adding support so that only one line needs to be uncommented when using MAX485-board that needs the RTS-pin.